### PR TITLE
Configurable project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Global configuration settings with the default values
     fugitive_sync = false
     -- triggers `RsyncUp` when you save a file.
     sync_on_save = true
-    -- the path of your project configuration
+    -- the path to the project configuration
     project_config_path = ".nvim/rsync.toml"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ use {
 
 ## Usage
 
-**rsync.nvim** looks for `.nvim/rsync.toml` in the root of your project.
+**rsync.nvim** looks for `.nvim/rsync.toml` file by default in the root of
+your project. The path can also be set with the `project_config_path`
+key in the plugin configuration.
 
 The current options available:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Global configuration settings with the default values
     fugitive_sync = false
     -- triggers `RsyncUp` when you save a file.
     sync_on_save = true
+    -- the path of your project configuration
+    project_config_path = ".nvim/rsync.toml"
 }
 ```
 

--- a/doc/rsync.txt
+++ b/doc/rsync.txt
@@ -8,7 +8,9 @@ on save. So if you have a remote evironment but want to use you local
 tools to edit files then this is the perfect plugin for you!
 
                                                           *rsync-config*
-|rsync.nvim| looks for `.nvim/rsync.toml` file in the root of your project.
+|rsync.nvim| looks for `.nvim/rsync.toml` file by default in the root of
+your project. The path can also be set with the `project_config_path`
+key in the plugin configuration.
 The configuration options valid are:
 
 - remote_path

--- a/lua/rsync/config.lua
+++ b/lua/rsync/config.lua
@@ -2,6 +2,7 @@ local config = {}
 config.values = {
     fugitive_sync = false,
     sync_on_save = true,
+    project_config_path = ".nvim/rsync.toml",
 }
 
 function config.set_defaults(user_defaults)

--- a/lua/rsync/project.lua
+++ b/lua/rsync/project.lua
@@ -4,12 +4,13 @@
 local rsync_nvim = require("rsync_nvim")
 local path = require("plenary.path")
 local log = require("rsync.log")
+local config = require("rsync.config")
 
 local project = {}
 
 _RsyncProjectConfigs = _RsyncProjectConfigs or {}
 
-local config_path = ".nvim/rsync.toml"
+local config_path = config.values.project_config_path
 
 --- try find a config file.
 -- @return string, or nil


### PR DESCRIPTION
Not everyone wants to use `.nvim/rsync.toml`, this allows the user to use a different path.