### PR TITLE
Hooks: on_exit, on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Global configuration settings with the default values
     on_exit = function(code, command)
     end,
     -- called when the rsync command prints to stderr, provides the data and the used command
-    on_error = function(data, command)
+    on_stderr = function(data, command)
     end,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ Global configuration settings with the default values
 ```lua
 {
     -- triggers `RsyncUp` when fugitive thinks something might have changed in the repo.
-    fugitive_sync = false
+    fugitive_sync = false,
     -- triggers `RsyncUp` when you save a file.
     sync_on_save = true
     -- the path to the project configuration
     project_config_path = ".nvim/rsync.toml"
+    -- called when the rsync command exits, provides the exit code and the used command
+    on_exit = function(code, command)
+    end,
+    -- called when the rsync command prints to stderr, provides the data and the used command
+    on_error = function(data, command)
+    end,
 }
 ```
 

--- a/lua/rsync/config.lua
+++ b/lua/rsync/config.lua
@@ -4,7 +4,7 @@ config.values = {
     sync_on_save = true,
     project_config_path = ".nvim/rsync.toml",
     on_exit = function(code, command) end,
-    on_error = function(data, command) end,
+    on_stderr = function(data, command) end,
 }
 
 function config.set_defaults(user_defaults)

--- a/lua/rsync/config.lua
+++ b/lua/rsync/config.lua
@@ -3,6 +3,8 @@ config.values = {
     fugitive_sync = false,
     sync_on_save = true,
     project_config_path = ".nvim/rsync.toml",
+    on_exit = function(code, command) end,
+    on_error = function(data, command) end,
 }
 
 function config.set_defaults(user_defaults)

--- a/lua/rsync/sync.lua
+++ b/lua/rsync/sync.lua
@@ -32,7 +32,7 @@ local function safe_sync(command, on_start, on_exit)
                 log.info(string.format("safe_sync command: '%s', on_stderr: '%s'", command, vim.inspect(output)))
             end
 
-            config.values.on_error(output, command)
+            config.values.on_stderr(output, command)
         end,
 
         -- job done executing

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -192,7 +192,7 @@ describe("rsync", function()
                         on_exit = function(code, command)
                             Res_code = code
                         end,
-                        on_error = function(data, command)
+                        on_stderr = function(data, command)
                             Res_data = data
                         end,
                     })
@@ -209,31 +209,29 @@ describe("rsync", function()
             end)
 
             it("error, on_exit called, on_error called", function()
-                setup(function()
-                    -- use an unreachable host to produce an error
-                    helpers.write_file(".nvim/rsync.toml", { 'remote_path = "ureachable@host:/tmp/rsync_test"' })
+                -- use an unreachable host to produce an error
+                helpers.write_file(".nvim/rsync.toml", { 'remote_path = "ureachable@host:/tmp/rsync_test"' })
 
-                    Res_code = -1
-                    Res_data = ""
-                    require("rsync").setup({
-                        on_exit = function(code, _)
-                            Res_code = code
-                        end,
-                        on_error = function(data, _)
-                            Res_data = data
-                        end,
-                    })
+                Res_code = -1
+                Res_data = ""
+                require("rsync").setup({
+                    on_exit = function(code, _)
+                        Res_code = code
+                    end,
+                    on_stderr = function(data, _)
+                        Res_data = data
+                    end,
+                })
 
-                    vim.cmd.w()
+                vim.cmd.w()
 
-                    helpers.wait_sync()
-                    assert.equals(Res_code, 255)
-                    local has_error, _ = string.find(Res_data[1], "ssh: Could not resolve hostname host")
-                    assert.equals(has_error, 1)
+                helpers.wait_sync()
+                assert.equals(Res_code, 255)
+                local has_error, _ = string.find(Res_data[1], "ssh: Could not resolve hostname host")
+                assert.equals(has_error, 1)
 
-                    -- restore default
-                    require("rsync").setup({ on_exit = function(_, _) end, on_error = function(_, _) end })
-                end)
+                -- restore default
+                require("rsync").setup({ on_exit = function(_, _) end, on_error = function(_, _) end })
             end)
         end)
     end)

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -186,22 +186,22 @@ describe("rsync", function()
         describe("hooks", function()
             it("success, on_exit called, on_error not called", function()
                 setup(function()
-                    Res_code = -1
-                    Res_data = ""
+                    local res_code = -1
+                    local res_data = ""
                     require("rsync").setup({
                         on_exit = function(code, command)
-                            Res_code = code
+                            res_code = code
                         end,
                         on_stderr = function(data, command)
-                            Res_data = data
+                            res_data = data
                         end,
                     })
 
                     vim.cmd.w()
 
                     helpers.wait_sync()
-                    assert.equals(Res_code, 0)
-                    assert.equals(Res_data[1], "")
+                    assert.equals(res_code, 0)
+                    assert.equals(res_data[1], "")
 
                     -- restore default
                     require("rsync").setup({ on_exit = function(_, _) end, on_error = function(_, _) end })
@@ -212,22 +212,22 @@ describe("rsync", function()
                 -- use an unreachable host to produce an error
                 helpers.write_file(".nvim/rsync.toml", { 'remote_path = "ureachable@host:/tmp/rsync_test"' })
 
-                Res_code = -1
-                Res_data = ""
+                local res_code = -1
+                local res_data = ""
                 require("rsync").setup({
                     on_exit = function(code, _)
-                        Res_code = code
+                        res_code = code
                     end,
                     on_stderr = function(data, _)
-                        Res_data = data
+                        res_data = data
                     end,
                 })
 
                 vim.cmd.w()
 
                 helpers.wait_sync()
-                assert.equals(Res_code, 255)
-                local has_error, _ = string.find(Res_data[1], "ssh: Could not resolve hostname host")
+                assert.equals(res_code, 255)
+                local has_error, _ = string.find(res_data[1], "ssh: Could not resolve hostname host")
                 assert.equals(has_error, 1)
 
                 -- restore default


### PR DESCRIPTION
Added two hooks, on_exit and on_error, to be called when rsync exits, or errors. This fixes #81 