### PR TITLE
Reload project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ remote_includes = ["build.log", "build/generated.json"]
 
 ## Commands
 
-Name               | Action
--------------------|-------
-RsyncDown          | Sync all files from remote* to local folder.
-RsyncDownFile      | Sync current file from remote to local folder.
-RsyncUp            | Sync all files from local* to remote folder.
-RsyncUpFile        | Sync current file from local to remote. This requires rsync version >= 3.2.3
-RsyncLog           | Open log file for rsync.nvim.
-RsyncConfig        | Print out user config.
-RsyncProjectConfig | Print out current project config.
+Name                      | Action
+------------------------- |-------
+RsyncDown                 | Sync all files from remote* to local folder.
+RsyncDownFile             | Sync current file from remote to local folder.
+RsyncUp                   | Sync all files from local* to remote folder.
+RsyncUpFile               | Sync current file from local to remote. This requires rsync version >= 3.2.3
+RsyncLog                  | Open log file for rsync.nvim.
+RsyncConfig               | Print out user config.
+RsyncProjectConfig show   | Print out current project config.
+RsyncProjectConfig reload | Reload the project config.
 
 *: Files which are excluded are, everything in .gitignore and .nvim folder.
 

--- a/doc/rsync.txt
+++ b/doc/rsync.txt
@@ -56,6 +56,14 @@ The configuration options valid are:
         require("rsync.project").get_config_table()
 <
 
+# TODO dunno yet how to show args in docs
+                                             *:RsyncReloadProjectConfig*
+:RsyncReloadProjectConfig
+    Reload the current project config.
+>lua
+        require("rsync.project").reload_config()
+<
+
 ==============================================================================
 3. Functions                                            *rsync-function*
 

--- a/doc/rsync.txt
+++ b/doc/rsync.txt
@@ -53,7 +53,7 @@ The configuration options valid are:
     Print out current project config. If table is needed to extend this
     plugin then use:
 >lua
-        require("rsync.project").get_project_config()
+        require("rsync.project").get_config_table()
 <
 
 ==============================================================================

--- a/lua/rsync/init.lua
+++ b/lua/rsync/init.lua
@@ -60,9 +60,21 @@ vim.api.nvim_create_user_command("RsyncConfig", function()
     vim.print(config.values)
 end, {})
 
-vim.api.nvim_create_user_command("RsyncProjectConfig", function()
-    vim.print(project.get_config_table())
-end, {})
+vim.api.nvim_create_user_command("RsyncProjectConfig", function(opts)
+    local cmd = opts.fargs[1]
+    if cmd == nil or cmd == "show" then
+        vim.print(project.get_config_table())
+    elseif cmd == "reload" then
+        project.reload_config()
+    else
+        log.error(string.format("Unknown subcommand: '%s'", cmd))
+    end
+end, {
+    nargs = 1,
+    complete = function(ArgLead, CmdLine, CursorPos)
+        return { "show", "reload" }
+    end,
+})
 
 --- get current sync status of project
 M.status = function()

--- a/lua/rsync/project.lua
+++ b/lua/rsync/project.lua
@@ -83,6 +83,17 @@ function project.get_config_table()
     end
 end
 
+--- Reload project config
+function project.reload_config()
+    local config_file_path = get_config_file()
+    if config_file_path == nil then
+        return
+    end
+
+    local project_path = get_project_path(config_file_path)
+    _RsyncProjectConfigs[project_path] = nil
+end
+
 --- Run passed function if project config is found
 --- @param fn function fuction to call if config is found
 function project:run(fn)

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -27,14 +27,34 @@ describe("rsync", function()
             assert.equals(err, "")
         end)
 
-        it("RsyncProjectConfig", function()
+        it("RsyncProjectConfig show", function()
             helpers.write_file(".nvim/rsync.toml", { 'remote_path = "' .. helpers.dest .. '/"' })
             helpers.write_file("test.c", { "eueueu" })
             helpers.assert_file_not_copied("test.c")
 
-            local status, err = pcall(vim.cmd.RsyncProjectConfig)
+            local status, err = pcall(vim.cmd.RsyncProjectConfig, "show")
             assert.equals(status, true)
             assert.equals(err, "")
+        end)
+
+        it("RsyncProjectConfig reload", function()
+            require("rsync").setup({ sync_on_save = false })
+
+            local project = require("rsync.project")
+
+            -- create an initial rsync.toml with a path
+            helpers.write_file(".nvim/rsync.toml", { 'remote_path = "path1"' })
+            assert.equals(project.get_config_table().remote_path, "path1")
+
+            -- change the path, and reload the config
+            helpers.write_file(".nvim/rsync.toml", { 'remote_path = "path2"' })
+            local status, err = pcall(vim.cmd.RsyncProjectConfig, "reload")
+            assert.equals(status, true)
+            assert.equals(err, "")
+            assert.equals(project.get_config_table().remote_path, "path2")
+
+            -- restore defaults
+            require("rsync").setup({ sync_on_save = true })
         end)
     end)
 


### PR DESCRIPTION
As you said added it as part of `RsyncProjectConfig`,
`RsyncProjectConfig show`, `RsyncProjectConfig reload`.

Changes default behavior, I can check how to use default args if none is provided.

There is a docs todo, not sure how to write docs for args, if you have a help.txt from the top of your head which I could use as an example that would be noice.
