### PR TITLE
fix: File commands use wrong path if not in project root

### DIFF
--- a/lua/rsync/init.lua
+++ b/lua/rsync/init.lua
@@ -62,16 +62,16 @@ vim.api.nvim_create_user_command("RsyncUp", function()
 end, {})
 
 vim.api.nvim_create_user_command("RsyncDownFile", function(opts)
-    local file_relative = opts.fargs[1] or vim.fn.expand("%:.")
-    sync.sync_down_file(file_relative)
+    local file_path = opts.fargs[1] or vim.fn.expand("%:p")
+    sync.sync_down_file(file_path)
 end, {
     nargs = "?",
     complete = "file",
 })
 
 vim.api.nvim_create_user_command("RsyncUpFile", function(opts)
-    local file_relative = opts.fargs[1] or vim.fn.expand("%:.")
-    sync.sync_up_file(file_relative)
+    local file_path = opts.fargs[1] or vim.fn.expand("%:p")
+    sync.sync_up_file(file_path)
 end, {
     nargs = "?",
     complete = "file",

--- a/lua/rsync/sync.lua
+++ b/lua/rsync/sync.lua
@@ -6,6 +6,7 @@
 local project = require("rsync.project")
 local log = require("rsync.log")
 local config = require("rsync.config")
+local path = require("plenary.path")
 
 FileSyncStates = {
     DONE = 0,
@@ -46,6 +47,8 @@ local function safe_sync(command, on_start, on_exit)
         end,
         stdout_buffered = true,
         stderr_buffered = true,
+        -- run from project root
+        cwd = project.get_config_table().project_path
     })
 
     if res == -1 then
@@ -153,16 +156,14 @@ function sync.sync_up_file(filename)
         end
 
         -- TODO move to function
-        local full = vim.fn.expand("%:p")
         local name = vim.fn.expand("%:t")
-        local path = require("plenary.path")
 
-        local relative_path = path:new(full):make_relative(config_table["project_path"])
+        local relative_path = path:new(filename):make_relative(config_table["project_path"])
         local rpath_no_filename = string.sub(relative_path, 1, -(1 + string.len(name)))
 
         local command = "rsync -az --mkpath "
             .. config_table.project_path
-            .. filename
+            .. relative_path
             .. " "
             .. config_table.remote_path
             .. rpath_no_filename
@@ -264,7 +265,8 @@ end
 --- @param destination_path string the destination path which file will be synced from
 --- @return string #valid rsync command
 local function compose_sync_down_file_command(file_path, project_path, destination_path)
-    local command = "rsync -varz " .. destination_path .. file_path .. " " .. project_path .. file_path
+    local relative_path = path:new(file_path):make_relative(project_path)
+    local command = "rsync -varz " .. destination_path .. relative_path .. " " .. file_path
     return command
 end
 

--- a/lua/rsync/sync.lua
+++ b/lua/rsync/sync.lua
@@ -48,7 +48,7 @@ local function safe_sync(command, on_start, on_exit)
         stdout_buffered = true,
         stderr_buffered = true,
         -- run from project root
-        cwd = project.get_config_table().project_path
+        cwd = project.get_config_table().project_path,
     })
 
     if res == -1 then

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -270,6 +270,24 @@ describe("rsync", function()
                 end)
             end)
 
+            it("RsyncDownFile in sub-folder", function()
+                setup(function()
+                    helpers.mkdir("build")
+                    -- current active file
+                    helpers.write_file("build/aabb.txt", { "obobob12" })
+                    helpers.mkdir_remote("")
+                    helpers.mkdir_remote("build")
+                    helpers.write_remote_file("build/aabb.txt", { "121212" })
+
+                    -- change pwd to build folder
+                    vim.cmd.cd("build")
+                    vim.cmd.RsyncDownFile()
+
+                    helpers.wait_sync_file()
+                    helpers.assert_file("build/aabb.txt")
+                end)
+            end)
+
             it("RsyncUpFile is aborted", function()
                 setup(function()
                     vim.cmd.RsyncUpFile()
@@ -293,8 +311,10 @@ describe("rsync", function()
                     -- this is needed due to rsync will not create remote directories
                     -- if they do not exist
                     helpers.mkdir_remote("sub")
-
+                    -- make sure you don't have to be in project root
+                    vim.cmd.cd("sub")
                     vim.cmd.RsyncUpFile()
+
                     helpers.wait_sync_file()
                     helpers.assert_file("sub/second_test.tt")
                 end)


### PR DESCRIPTION
File commands where using relative paths when you actually should be able to be in any folder inside the project root dir.

This fixes #111 