### PR TITLE
ignore comments in ignore files

### DIFF
--- a/lua/rsync/sync.lua
+++ b/lua/rsync/sync.lua
@@ -74,10 +74,12 @@ local function create_filters(filter_paths)
 
         if f ~= nil then
             for line in f:lines() do
-                if line:sub(1, 1) == "!" then
-                    include = include .. "--include='" .. line:sub(2, -1) .. "' "
-                else
-                    exclude = exclude .. "--exclude='" .. line .. "' "
+                if line:sub(1, 1) ~= "#" then
+                    if line:sub(1, 1) == "!" then
+                        include = include .. "--include='" .. line:sub(2, -1) .. "' "
+                    else
+                        exclude = exclude .. "--exclude='" .. line .. "' "
+                    end
                 end
             end
         end

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -506,6 +506,15 @@ describe("rsync", function()
             end)
         end)
 
+        it("on RsyncUp with gitignore comments", function()
+            setup_with_gitignore(function()
+                -- Overwrite .gitignore w/ added comments
+                helpers.write_file(".gitignore", { "# Comment 1",  "should_ignore.txt", "# Another comment" })
+                vim.cmd.RsyncUp()
+                helpers.wait_sync()
+            end)
+        end)
+
         it("on RsyncUpFile", function()
             setup_with_gitignore(function()
                 helpers.write_file("second_test.tt", { "labbal" })

--- a/tests/rsync/rsync_spec.lua
+++ b/tests/rsync/rsync_spec.lua
@@ -509,7 +509,7 @@ describe("rsync", function()
         it("on RsyncUp with gitignore comments", function()
             setup_with_gitignore(function()
                 -- Overwrite .gitignore w/ added comments
-                helpers.write_file(".gitignore", { "# Comment 1",  "should_ignore.txt", "# Another comment" })
+                helpers.write_file(".gitignore", { "# Comment 1", "should_ignore.txt", "# Another comment" })
                 vim.cmd.RsyncUp()
                 helpers.wait_sync()
             end)


### PR DESCRIPTION
Hi, great plugin! Just a tiny PR to handle commented out lines in ignore files.  Tested locally.  I have not yet been able to run `make test` successfully:

```
nvim --headless --noplugin -u /Users/garrett/github/garrett361/rsync.nvim/scripts/minimal.vim -c "PlenaryBustedDirectory /Users/garrett/github/garrett361/rsync.nvim/tests/rsync/ {minimal_init = '/Users/garrett/github/garrett361/rsync.nvim/tests/minimal_init.lua'}"
Error detected while processing command line:
E492: Not an editor command: PlenaryBustedDirectory /Users/garrett/github/garrett361/rsync.nvim/tests/rsync/ {minimal_init = '/Users/garrett/github/garrett361/rsync.nvim/tests/minimal_init.lua'}^Cmake: *** [test] Interrupt: 2
```

But I think it should be easy enough to add automated tests once I get the environment fixed.

Does this look good, otherwise?