### PR TITLE
fix: nil check for setup config

### DIFF
--- a/lua/rsync/config.lua
+++ b/lua/rsync/config.lua
@@ -23,6 +23,10 @@ local config = {
 ---Apply configuration from passed in table
 ---@param user_defaults table
 function M.apply_config(user_defaults)
+    if user_defaults == nil or type(user_defaults) ~= "table" then
+        return
+    end
+
     for key, value in pairs(user_defaults) do
         config[key] = value
     end


### PR DESCRIPTION
Check nil for user setup config. If user do not pass config for setup likes `require("rsync").setup()`, the error will occurs
```
E5108: Error executing lua .../.local/share/nvim/lazy/rsync.nvim/lua/rsync/config.lua:26: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
        [C]: in function 'pairs'
        .../.local/share/nvim/lazy/rsync.nvim/lua/rsync/config.lua:26: in function 'apply_config'
        .../.local/share/nvim/lazy/rsync.nvim/lua/rsync/init.lua:43: in function 'setup'
        .../.config/nvim/lua/usr/init.lua:67: in main chunk
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
```